### PR TITLE
Fix the setup script for Setuptools URL

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
 ## Install setuptools
 
 - name: Download the setup script for Setuptools
-  get_url: url=https://bitbucket.org/pypa/setuptools/raw/bootstrap/ez_setup.py dest={{download_dest}}
+  get_url: url=https://bootstrap.pypa.io/ez_setup.py dest={{download_dest}}
   tags: pip
 
 - name: Install Setuptools


### PR DESCRIPTION
Hello.

The setup script for Setuptools has moved. (See https://bitbucket.org/pypa/setuptools/)
So I fixed.

Thanks.